### PR TITLE
Add initial models

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.{ex,exs}]
+indent_style = space
+end_of_line = lf
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,4 @@
 indent_style = space
 end_of_line = lf
 indent_size = 2
+trim_trailing_whitespace = true

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -43,4 +43,6 @@ config :nupm, NuPM.Repo,
   password: "postgres",
   database: "nupm_dev",
   hostname: "localhost",
-  pool_size: 10
+  pool_size: 10,
+  migration_primary_key: [id: :uuid, type: :binary_id],
+	migration_timestamps: [type: :utc_datetime]

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,4 +16,6 @@ config :nupm, NuPM.Repo,
   password: "postgres",
   database: "nupm_test",
   hostname: "localhost",
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  migration_primary_key: [id: :uuid, type: :binary_id],
+	migration_timestamps: [type: :utc_datetime]

--- a/lib/nupm/package.ex
+++ b/lib/nupm/package.ex
@@ -1,5 +1,6 @@
 defmodule NuPM.Package do
-  use Ecto.Schema
+  use NuPM.Schema
+  import Ecto.Changeset
 
   schema "packages" do
     field :title, :string
@@ -11,5 +12,22 @@ defmodule NuPM.Package do
     field :license, :string
 
     has_many :versions, NuPM.Version
+    
+    timestamps()
+  end
+
+  def changeset(package, params \\ %{}) do
+    package
+    |> cast(params, [
+      :title,
+      :description,
+      :repository,
+      :website,
+      :author,
+      :author_email,
+      :license
+    ])
+    |> validate_required([:title])
+    |> unique_constraint(:title)
   end
 end

--- a/lib/nupm/package.ex
+++ b/lib/nupm/package.ex
@@ -2,31 +2,22 @@ defmodule NuPM.Package do
   use NuPM.Schema
   import Ecto.Changeset
 
+  @module_doc """
+  A Package represents the entire history of a package, including every release
+  of the package.
+  """
+
   schema "packages" do
     field :title, :string
-    field :description, :string
-    field :repository, :string
-    field :website, :string
-    field :author, :string
-    field :author_email, :string
-    field :license, :string
 
     has_many :versions, NuPM.Version
-    
+
     timestamps()
   end
 
   def changeset(package, params \\ %{}) do
     package
-    |> cast(params, [
-      :title,
-      :description,
-      :repository,
-      :website,
-      :author,
-      :author_email,
-      :license
-    ])
+    |> cast(params, [:title])
     |> validate_required([:title])
     |> unique_constraint(:title)
   end

--- a/lib/nupm/package.ex
+++ b/lib/nupm/package.ex
@@ -1,0 +1,15 @@
+defmodule NuPM.Package do
+  use Ecto.Schema
+
+  schema "packages" do
+    field :title, :string
+    field :description, :string
+    field :repository, :string
+    field :website, :string
+    field :author, :string
+    field :author_email, :string
+    field :license, :string
+
+    has_many :versions, NuPM.Version
+  end
+end

--- a/lib/nupm/schema.ex
+++ b/lib/nupm/schema.ex
@@ -1,0 +1,9 @@
+defmodule NuPM.Schema do
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+    end
+  end
+end

--- a/lib/nupm/version.ex
+++ b/lib/nupm/version.ex
@@ -1,0 +1,10 @@
+defmodule NuPM.Version do
+  use Ecto.Schema
+
+  schema "versions" do
+    field :number, :string
+    field :readme, :string
+
+    belongs_to :package, NuPM.Package
+  end
+end

--- a/lib/nupm/version.ex
+++ b/lib/nupm/version.ex
@@ -3,17 +3,36 @@ defmodule NuPM.Version do
   import Ecto.Changeset
 
   schema "versions" do
-    field :number, :string
+    field :number, :string, primary_key: true
+    field :description, :string
+    field :repository, :string
+    field :website, :string
+    field :author, :string
+    field :author_email, :string
+    field :license, :string
+    field :metafile, :string
     field :readme, :string
 
-    belongs_to :package, NuPM.Package
+    belongs_to :package, NuPM.Package, primary_key: true
 
     timestamps()
   end
 
   def changeset(version, params \\ %{}) do
     version
-    |> cast(params, [:number, :readme])
-    |> validate_required([:number])
+    |> cast(params, [
+      :description,
+      :repository,
+      :website,
+      :author,
+      :author_email,
+      :license,
+      :number,
+      :readme,
+      :package_id])
+    |> validate_required([:number, :package_id])
+    |> assoc_constraint(:package)
+    |> foreign_key_constraint(:package_id)
+    |> unique_constraint(:pkey, name: :versions_number_package_id_index)
   end
 end

--- a/lib/nupm/version.ex
+++ b/lib/nupm/version.ex
@@ -1,10 +1,19 @@
 defmodule NuPM.Version do
-  use Ecto.Schema
+  use NuPM.Schema
+  import Ecto.Changeset
 
   schema "versions" do
     field :number, :string
     field :readme, :string
 
     belongs_to :package, NuPM.Package
+
+    timestamps()
+  end
+
+  def changeset(version, params \\ %{}) do
+    version
+    |> cast(params, [:number, :readme])
+    |> validate_required([:number])
   end
 end

--- a/priv/repo/migrations/20171117232612_add_package_versions.exs
+++ b/priv/repo/migrations/20171117232612_add_package_versions.exs
@@ -4,7 +4,7 @@ defmodule NuPM.Repo.Migrations.AddPackageVersions do
   def change do
     create table(:packages) do
       add :title, :string
-      add :description, :string
+      add :description, :text
       add :repository, :string
       add :website, :string
       add :author, :string
@@ -16,7 +16,7 @@ defmodule NuPM.Repo.Migrations.AddPackageVersions do
 
 		create table(:versions) do
 			add :number, :string
-			add :readme, :string
+			add :readme, :text
 
 			add :package_id, references(:packages)
 

--- a/priv/repo/migrations/20171117232612_add_package_versions.exs
+++ b/priv/repo/migrations/20171117232612_add_package_versions.exs
@@ -4,6 +4,16 @@ defmodule NuPM.Repo.Migrations.AddPackageVersions do
   def change do
     create table(:packages) do
       add :title, :string
+
+      timestamps()
+    end
+
+    create index(:packages, [:title], unique: true)
+
+		create table(:versions) do
+			add :number, :string
+      add :metafile, :text
+			add :readme, :text
       add :description, :text
       add :repository, :string
       add :website, :string
@@ -11,16 +21,11 @@ defmodule NuPM.Repo.Migrations.AddPackageVersions do
       add :author_email, :string
       add :license, :string
 
-      timestamps()
-    end
-
-		create table(:versions) do
-			add :number, :string
-			add :readme, :text
-
 			add :package_id, references(:packages)
 
 			timestamps()
 		end
+
+    create index(:versions, [:number, :package_id], unique: true)
   end
 end

--- a/priv/repo/migrations/20171117232612_add_package_versions.exs
+++ b/priv/repo/migrations/20171117232612_add_package_versions.exs
@@ -13,7 +13,7 @@ defmodule NuPM.Repo.Migrations.AddPackageVersions do
 		create table(:versions) do
 			add :number, :string
       add :metafile, :text
-			add :readme, :text
+      add :readme, :text
       add :description, :text
       add :repository, :string
       add :website, :string

--- a/priv/repo/migrations/20171117232612_add_package_versions.exs
+++ b/priv/repo/migrations/20171117232612_add_package_versions.exs
@@ -1,0 +1,26 @@
+defmodule NuPM.Repo.Migrations.AddPackageVersions do
+  use Ecto.Migration
+
+  def change do
+    create table(:packages) do
+      add :title, :string
+      add :description, :string
+      add :repository, :string
+      add :website, :string
+      add :author, :string
+      add :author_email, :string
+      add :license, :string
+
+      timestamps()
+    end
+
+		create table(:versions) do
+			add :number, :string
+			add :readme, :string
+
+			add :package_id, references(:packages)
+
+			timestamps()
+		end
+  end
+end

--- a/test/nupm/package_test.exs
+++ b/test/nupm/package_test.exs
@@ -1,0 +1,31 @@
+defmodule NuPM.PackageTest do
+  use ExUnit.Case, async: true
+
+  alias NuPM.{Repo,Package}
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+  end
+
+  test "create package" do
+    params = %{title: "foobar"}
+    cs = Package.changeset(%Package{}, params)
+
+    assert {:ok, %Package{} = package} = Repo.insert(cs)
+
+    assert is_binary(package.id)
+    assert package.title == params[:title]
+  end
+
+  test "create package w/o title" do
+    cs = Package.changeset(%Package{}, %{})
+    assert {:error, _} = Repo.insert(cs)
+  end
+
+  test "create package w/ duplicate name" do
+    cs = Package.changeset(%Package{}, %{title: "foobar"})
+    {:ok, _} = Repo.insert(cs)
+
+    assert {:error, _} = Repo.insert(cs)
+  end
+end

--- a/test/nupm/version_test.exs
+++ b/test/nupm/version_test.exs
@@ -1,0 +1,50 @@
+defmodule NuPM.VersionTest do
+  use ExUnit.Case, async: true
+
+  alias NuPM.{Repo, Package, Version}
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    cs = Package.changeset(%Package{}, %{title: "foobar"})
+    package = Repo.insert!(cs)
+
+    {:ok, %{package: package}}
+  end
+
+  test "create version", %{package: package} do
+    cs = Version.changeset(%Version{}, %{package_id: package.id, number: "1.0.0"})
+    assert {:ok, %Version{id: id}} = Repo.insert(cs)
+
+    # Ensure our package.version relationship works
+    package = Repo.preload(package, :versions)
+    assert length(package.versions) == 1
+    assert List.first(package.versions).id == id
+  end
+
+  test "create version w/ existing number", %{package: package} do
+    cs = Version.changeset(%Version{}, %{package_id: package.id, number: "1.0.0"})
+    assert {:ok, _} = Repo.insert(cs)
+    assert {:error, _} = Repo.insert(cs)
+  end
+
+  test "create multiple versions for existing package", %{package: package} do
+    cs1 = Version.changeset(%Version{}, %{package_id: package.id, number: "1.0.0"})
+    cs2 = Version.changeset(%Version{}, %{package_id: package.id, number: "1.0.1"})
+    assert {:ok, _} = Repo.insert(cs1)
+    assert {:ok, _} = Repo.insert(cs2)
+
+    package = Repo.preload(package, :versions)
+    assert length(package.versions) == 2
+  end
+
+  test "create version w/o valid number", %{package: package} do
+    cs = Version.changeset(%Version{}, %{package_id: package.id})
+    assert {:error, _} = Repo.insert(cs)
+  end
+
+  test "create version w/ invalid reference to package" do
+    cs = Version.changeset(%Version{}, %{package_id: "a7ac0e4f-485e-48a0-a831-50756dac64f6", number: "1.0.0"})
+    assert {:error, _} = Repo.insert(cs)
+  end
+end


### PR DESCRIPTION
Keeping it simple, we'll start with the initial models we'll need. Because we're building a javascript package registry, let's use package.json as a reference.

## Package
### Attributes
* Title
* Description
* Repository
* Website
* Author
* License
* Primary Key (UUID)

### Relationships
* Has many `Versions`
* Has many `Keywords`
  * May put off for now

## Version
A `Package` can have one or more versions associated with it. Each version is essentially a snapshot of the package at a point in time.
### Attributes
* Version Number
  * Type should be string
  * No enforcement over version format (semver, etc...)
* README

### Relationships
* Has many `Dependencies` (associated through `Package`)
  * We'll ignore dependency version requirements for this project